### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - CI and devcontainer use Python 3.14.
 - GitHub Actions modernized: pinned action SHAs, composite `setup-uv`, unified `ci.yml` and `release.yml` (auto-tag on `main` when missing, publish on `v*` tag push).
 
+## 0.14.0
+
+- Remove dependencies restrictions
+
 ## 0.13.0
 
 - Add PEP 561 `py.typed` marker for type checkers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyogero"
-version = "0.13.0"
+version = "0.14.0"
 description = "Ogero API module"
 readme = "README.md"
 license = "MIT"
@@ -13,17 +13,16 @@ keywords = ["ogero", "internet", "api", "lebanon"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.12,<4"
+requires-python = ">=3.14"
 dependencies = [
-    "requests>=2.32.3,<=2.32.5",
-    "beautifulsoup4>=4.12.3,<=4.13.3",
-    "aiohttp>=3.10.3,<=3.13.3",
-    "pydantic>=2.0,<=2.12.2",
-    "tzdata>=2024.1",
+    "requests>=2.32.3",
+    "beautifulsoup4>=4.12.3",
+    "aiohttp>=3.10.3",
+    "pydantic>=2.0",
+    "tzdata>=2026.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ wheels = [
 
 [[package]]
 name = "pyogero"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Bump version to **0.14.0** and relax runtime dependency pins (minimum versions only, no upper caps).
- Require **Python 3.14+** and drop the Python 3.12 classifier.
- Update `tzdata` minimum to 2026.1.

## Motivation
Downstream projects (e.g. Home Assistant 2026.3.x) can install current compatible versions of aiohttp, pydantic, and related packages without conflicting with pyogero upper bounds.

## Test plan
- [ ] CI passes on this PR
- [ ] `uv sync` and `uv run pytest` on Python 3.14
- [ ] Tag `v0.14.0` and publish after merge (release workflow)
